### PR TITLE
Update Python versions and add classifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
+  - "3.6"
+  - "3.5"
   - "3.4"
-  - "3.3"
   - "2.7"
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install configparser; fi

--- a/flit.ini
+++ b/flit.ini
@@ -4,5 +4,11 @@ author = Thomas Kluyver
 author-email = thomas@kluyver.me.uk
 home-page = https://github.com/takluyver/entrypoints
 classifiers = License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
 requires-python = >=2.7
 requires = configparser (>=3.5); python_version == '2.7'

--- a/flit.ini
+++ b/flit.ini
@@ -5,10 +5,6 @@ author-email = thomas@kluyver.me.uk
 home-page = https://github.com/takluyver/entrypoints
 classifiers = License :: OSI Approved :: MIT License
     Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
 requires-python = >=2.7
 requires = configparser (>=3.5); python_version == '2.7'


### PR DESCRIPTION
Remove EOL Python version 3.3 and add 3.5 and 3.6, with classifiers. 

Python 3.3 is little used. Here's the pip installs for entrypoints from PyPI for last month:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  39.37% |        109,887 |
| 3.4            |  24.95% |         69,630 |
| 3.6            |  23.23% |         64,831 |
| 3.5            |  12.09% |         33,731 |
| 3.7            |   0.23% |            638 |
| 3.3            |   0.12% |            345 |
| 2.6            |   0.02% |             46 |
| 3.2            |   0.00% |              2 |
| 3.8            |   0.00% |              1 |

Source: `pypinfo --start-date -46 --end-date -19 --percent --pip --markdown entrypoints pyversion`