### PR TITLE
Allow only equal signs as config delimiters

### DIFF
--- a/entrypoints.py
+++ b/entrypoints.py
@@ -55,7 +55,7 @@ class NoSuchEntryPoint(Exception):
         return "No {!r} entry point found in group {!r}".format(self.name, self.group)
 
 
-class CaseSensitiveConfigParser(configparser.ConfigParser):
+class CaseSensitivearser(configparser.ConfigParser):
     optionxform = staticmethod(str)
 
 
@@ -146,7 +146,7 @@ def iter_files_distros(path=None, repeated_distro='first'):
                     info = z.getinfo('EGG-INFO/entry_points.txt')
                 except KeyError:
                     continue
-                cp = CaseSensitiveConfigParser()
+                cp = CaseSensitiveConfigParser(delimiters=('=',))
                 with z.open(info) as f:
                     fu = io.TextIOWrapper(f)
                     cp.read_file(fu,
@@ -167,7 +167,7 @@ def iter_files_distros(path=None, repeated_distro='first'):
                 distro_names_seen.add(distro.name)
             else:
                 distro = None
-            cp = CaseSensitiveConfigParser()
+            cp = CaseSensitiveConfigParser(delimiters=('=',))
             cp.read([path])
             yield cp, distro
 

--- a/entrypoints.py
+++ b/entrypoints.py
@@ -55,7 +55,7 @@ class NoSuchEntryPoint(Exception):
         return "No {!r} entry point found in group {!r}".format(self.name, self.group)
 
 
-class CaseSensitivearser(configparser.ConfigParser):
+class CaseSensitiveConfigParser(configparser.ConfigParser):
     optionxform = staticmethod(str)
 
 

--- a/entrypoints.py
+++ b/entrypoints.py
@@ -136,7 +136,7 @@ def iter_files_distros(path=None, repeated_distro='first'):
             if osp.isdir(folder):
                 ep_path = osp.join(folder, 'EGG-INFO', 'entry_points.txt')
                 if osp.isfile(ep_path):
-                    cp = CaseSensitiveConfigParser()
+                    cp = CaseSensitiveConfigParser(delimiters=('=',))
                     cp.read([ep_path])
                     yield cp, distro
 


### PR DESCRIPTION
According to the python [packaging specs](https://packaging.python.org/specifications/entry-points/), the name of an entry point can contain a colon, so this package should restrict keys in config file reading to only equal signs