### PR TITLE
Treat editable installs as distributions too

### DIFF
--- a/tests/samples/packages4/dev.egg-info/entry_points.txt
+++ b/tests/samples/packages4/dev.egg-info/entry_points.txt
@@ -1,0 +1,3 @@
+[entrypoints.test1]
+def = dev:def
+

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -17,6 +17,23 @@ sample_path = [
     osp.join(samples_dir, 'packages2', 'qux-0.4.egg'),
 ]
 
+def test_iter_files_distros():
+    result = entrypoints.iter_files_distros(path=sample_path)
+    # the sample_path has 4 unique items so iter_files_distros returns 4 tuples
+    assert len(list(result)) == 4
+
+    # testing a development, egg aka installed with pip install -e .
+    # these don't have version info in the .egg-info directory name
+    # (eg dev-0.0.1.egg-info)
+    path_with_dev = [osp.join(samples_dir, 'packages4')]
+    result = entrypoints.iter_files_distros(path=path_with_dev)
+    assert len(list(result)) == 1
+
+    # duplicate dev versions should still return one result
+    path_with_dev_duplicates = path_with_dev + path_with_dev
+    result = entrypoints.iter_files_distros(path=path_with_dev_duplicates)
+    assert len(list(result)) == 1
+
 def test_get_group_all():
     group = entrypoints.get_group_all('entrypoints.test1', sample_path)
     print(group)

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -30,7 +30,7 @@ def test_iter_files_distros():
     assert len(list(result)) == 1
 
     # duplicate dev versions should still return one result
-    path_with_dev_duplicates = path_with_dev + path_with_dev
+    path_with_dev_duplicates = path_with_dev * 2
     result = entrypoints.iter_files_distros(path=path_with_dev_duplicates)
     assert len(list(result)) == 1
 


### PR DESCRIPTION
**The problem**
While working on a [flake8](http://flake8.pycqa.org/en/latest/) plugin I noticed that the initialization of the plugin was running twice. 

**Analysis**
I found out that flake8 is using the `entrypoints` package since version 3.7 to look for installed entrypoints `flake8.extension`. It however sometimes detects duplicate entrypoints since distributions without a version will not be added to `distro_names_seen` (when there is not a '-' character in  the `distro_name_version` variable). So when it is added to the system path multiple times it will find the entrypoints multiple times.

This can be reproduced when installing a editable package `pip install -e .`
It will generate a `*.egg-info` folder as following:
```
flake8_isort.egg-info
flake8_isort.py
run_tests.py
setup.cfg
setup.py
```
When you run  the tests for this package, the current directory will be added to `sys.path` as well, so it can happen the same path is there twice. As `flake8_isort.egg-info` does not  contain a '-' it wont be added to `distro_names_seen`.

**Proposed solution** 
Treat development  installs as distributions too, that is implemented in this pull request.

_Alternative  solution_
De-duplicate the path in `iter_files_distros`:
```python
def iter_files_distros(path=None, repeated_distro='first'):
    if path is None:
        path = sys.path
    path = list(set(path))
```