### PR TITLE
Fix repr of EntryPoint

### DIFF
--- a/entrypoints.py
+++ b/entrypoints.py
@@ -73,8 +73,9 @@ class EntryPoint(object):
         self.distro = distro
 
     def __repr__(self):
-        return "EntryPoint(%r, %r, %r, %r)" % \
-            (self.name, self.module_name, self.object_name, self.distro)
+        return "EntryPoint(%r, %r, %r, extras=%r, distro=%r)" % \
+            (self.name, self.module_name, self.object_name, self.extras,
+             self.distro)
 
     def load(self):
         """Load the object to which this entry point refers.

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -114,3 +114,10 @@ def test_parse():
 def test_parse_bad():
     with pytest.raises(entrypoints.BadEntryPoint):
         entrypoints.EntryPoint.from_string("this won't work", 'foo')
+
+def test_repr():
+    ep = entrypoints.EntryPoint('foo', 'some.module', 'some.attr',
+                                extras=['extra1', 'extra2'], distro='distro')
+    assert repr(ep) == ("EntryPoint('foo', 'some.module', 'some.attr', "
+                        "extras=['extra1', 'extra2'], distro='distro')")
+


### PR DESCRIPTION
I noticed that ``__repr__`` of an entrypoint was missing the ``extras`` section.

With this change:

```
$ python -m entrypoints
[EntryPoint('py.test', 'pytest', 'main', extras=None, distro=Distribution('pytest', '5.1.2')),
 EntryPoint('pytest', 'pytest', 'main', extras=None, distro=Distribution('pytest', '5.1.2')),
 EntryPoint('wheel', 'wheel.cli', 'main', extras=None, distro=Distribution('wheel', '0.33.4-py3.7')),
 EntryPoint('easy_install', 'setuptools.command.easy_install', 'main', extras=None, distro=Distribution('setuptools', '41.0.1-py3.7')),
 EntryPoint('pip', 'pip._internal', 'main', extras=None, distro=Distribution('pip', '19.2.2-py3.7')),
 EntryPoint('pip3', 'pip._internal', 'main', extras=None, distro=Distribution('pip', '19.2.2-py3.7')),
 EntryPoint('pip3.7', 'pip._internal', 'main', extras=None, distro=Distribution('pip', '19.2.2-py3.7'))]
```