### PR TITLE
add a caching layer with a single cache

### DIFF
--- a/entrypoints_cache.py
+++ b/entrypoints_cache.py
@@ -178,11 +178,36 @@ get_group_named = _c.get_group_named
 get_single = _c.get_single
 
 
+def _timing_setup():
+    # Delete any existing cache file
+    digest, path_values = _hash_settings_for_path(sys.path)
+    filename = os.path.join(_get_cache_dir(), digest)
+    try:
+        os.unlink(filename)
+        log.debug('removed %s for test', filename)
+    except FileNotFoundError:
+        pass
+
+
+def _timing_test():
+    list(get_group_all(sys.argv[1]))
+
+
 if __name__ == '__main__':
+    import timeit
+
     logging.basicConfig(
         stream=sys.stderr,
         level=logging.DEBUG,
     )
-    for ep in get_group_all(sys.argv[1]):
-        print(ep)
-        ep.load()
+
+
+    t = timeit.Timer(
+        'entrypoints_cache._timing_test()',
+        'import entrypoints_cache; entrypoints_cache._timing_setup()',
+    )
+    first = t.timeit(1)
+    second = t.timeit(1)
+    print('1', first)
+    print('2', second)
+    print(first /second)

--- a/entrypoints_cache.py
+++ b/entrypoints_cache.py
@@ -64,6 +64,12 @@ def _hash_settings_for_path(path):
     paths = []
     stat = os.stat
     h = hashlib.sha1()
+
+    # Tie the cache to the python interpreter, in case it is part of a
+    # virtualenv.
+    h.update(sys.executable.encode('utf-8'))
+    h.update(sys.prefix.encode('utf-8'))
+
     for entry in path:
         mtime = _get_mtime(entry)
         h.update(entry.encode('utf-8'))
@@ -94,7 +100,11 @@ def _build_cacheable_data(path):
                 (name, epstr, distro.name, distro.version)
                 for name, epstr in group_val.items()
             )
-    return {'groups': groups}
+    return {
+        'groups': groups,
+        'sys.executable': sys.executable,
+        'sys.prefix': sys.prefix,
+    }
 
 
 class Cache:

--- a/entrypoints_cache.py
+++ b/entrypoints_cache.py
@@ -29,8 +29,9 @@ def _get_cache_dir():
     # Linux, Unix, AIX, etc.
     if os.name == 'posix' and sys.platform != 'darwin':
         # use ~/.cache if empty OR not set
-        return os.environ.get("XDG_CACHE_HOME", None) \
-              or os.path.expanduser('~/.cache/python-entrypoints')
+        base_path = os.environ.get("XDG_CACHE_HOME", None) \
+              or os.path.expanduser('~/.cache')
+        return os.path.join(base_path, 'python-entrypoints')
 
     # Mac OS
     elif sys.platform == 'darwin':
@@ -38,8 +39,9 @@ def _get_cache_dir():
 
     # Windows (hopefully)
     else:
-        return os.environ.get('LOCALAPPDATA', None) \
-               or os.path.expanduser('~\\AppData\\Local\\Python Entry Points')
+        base_path = os.environ.get('LOCALAPPDATA', None) \
+               or os.path.expanduser('~\\AppData\\Local')
+        return os.path.join(base_path, 'Python Entry Points')
 
 
 def _get_mtime(name):

--- a/entrypoints_cache.py
+++ b/entrypoints_cache.py
@@ -1,0 +1,145 @@
+"""Use a cache layer in front of entry point scanning."""
+
+import errno
+import hashlib
+import json
+import logging
+import os
+import os.path
+import struct
+import sys
+
+import entrypoints
+
+NoSuchEntryPoint = entrypoints.NoSuchEntryPoint
+BadEntryPoint = entrypoints.BadEntryPoint
+EntryPoint = entrypoints.EntryPoint
+
+
+log = logging.getLogger('entrypoints_cache')
+
+
+def _get_cache_dir():
+    """Locate a platform-appropriate cache directory to use.
+
+    Does not ensure that the cache directory exists.
+    """
+    # Linux, Unix, AIX, etc.
+    if os.name == 'posix' and sys.platform != 'darwin':
+        # use ~/.cache if empty OR not set
+        return os.environ.get("XDG_CACHE_HOME", None) \
+              or os.path.expanduser('~/.cache/python-entrypoints')
+
+    # Mac OS
+    elif sys.platform == 'darwin':
+        return os.path.expanduser('~/Library/Caches/Python Entry Points')
+
+    # Windows (hopefully)
+    else:
+        return os.environ.get('LOCALAPPDATA', None) \
+               or os.path.expanduser('~\\AppData\\Local\\Python Entry Points')
+
+
+def _hash_settings_for_path(path):
+    """Return a hash and the path settings that created it.
+    """
+    paths = []
+    stat = os.stat
+    h = hashlib.sha1()
+    for entry in path:
+        h.update(entry.encode('utf-8'))
+        try:
+            s = stat(entry)
+        except OSError as err:
+            if err.errno == errno.ENOENT:
+                continue
+            raise
+        else:
+            paths.append((entry, s.st_mtime))
+            h.update(struct.Struct('f').pack(s.st_mtime))
+
+    return (h.hexdigest(), paths)
+
+
+def _build_cacheable_data(path):
+    groups = {}
+    for config, distro in entrypoints.iter_files_distros(path=path):
+        for group_name, group_val in config.items():
+            groups.setdefault(group_name, []).extend(
+                (name, epstr, distro.name, distro.version)
+                for name, epstr in group_val.items()
+            )
+    return {'groups': groups}
+
+
+class Cache:
+
+    def __init__(self, cache_dir=None):
+        if cache_dir is None:
+            cache_dir = _get_cache_dir()
+        self._dir = cache_dir
+
+    def _get_data_for_path(self, path):
+        if path is None:
+            path = sys.path
+        digest, path_values = _hash_settings_for_path(path)
+        filename = os.path.join(self._dir, digest)
+        try:
+            log.debug('reading %s', filename)
+            with open(filename, 'r') as f:
+                data = json.load(f)
+        except (IOError, json.JSONDecodeError):
+            data = _build_cacheable_data(path)
+            data['path_values'] = path_values
+            try:
+                log.debug('writing to %s', filename)
+                os.makedirs(self._dir, exist_ok=True)
+                with open(filename, 'w') as f:
+                    json.dump(data, f)
+            except (IOError, OSError):
+                # Could not create cache dir or write file.
+                pass
+        return data
+
+    def get_group_all(self, group, path=None):
+        result = []
+        data = self._get_data_for_path(path)
+        group_data = data.get('groups', {}).get(group, [])
+        for name, epstr, distro_name, distro_version in group_data:
+            distro = entrypoints.Distribution(distro_name, distro_version)
+            with BadEntryPoint.err_to_warnings():
+                result.append(EntryPoint.from_string(epstr, name, distro))
+        return result
+
+    def get_group_named(self, group, path=None):
+        result = {}
+        for ep in self.get_group_all(group, path=path):
+            if ep.name not in result:
+                result[ep.name] = ep
+        return result
+
+    def get_single(self, group, name, path=None):
+        data = self._get_data_for_path(path)
+        group_data = data.get('groups', {}).get(group, [])
+        for name, epstr, distro_name, distro_version in group_data:
+            if name == name:
+                distro = entrypoints.Distribution(distro_name, distro_version)
+                with BadEntryPoint.err_to_warnings():
+                    return EntryPoint.from_string(epstr, name, distro)
+        raise NoSuchEntryPoint(group,  name)
+
+
+_c = Cache()
+get_group_all = _c.get_group_all
+get_group_named = _c.get_group_named
+get_single = _c.get_single
+
+
+if __name__ == '__main__':
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.DEBUG,
+    )
+    for ep in get_group_all(sys.argv[1]):
+        print(ep)
+        ep.load()

--- a/entrypoints_cache.py
+++ b/entrypoints_cache.py
@@ -113,10 +113,16 @@ class Cache:
         if cache_dir is None:
             cache_dir = _get_cache_dir()
         self._dir = cache_dir
+        self._internal = {}
 
     def _get_data_for_path(self, path):
         if path is None:
             path = sys.path
+
+        internal_key = tuple(path)
+        if internal_key in self._internal:
+            return self._internal[internal_key]
+
         digest, path_values = _hash_settings_for_path(path)
         filename = os.path.join(self._dir, digest)
         try:
@@ -134,6 +140,8 @@ class Cache:
             except (IOError, OSError):
                 # Could not create cache dir or write file.
                 pass
+
+        self._internal[internal_key] = data
         return data
 
     def get_group_all(self, group, path=None):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,96 @@
+# Copyright (c) Thomas Kluyver and contributors
+# Distributed under the terms of the MIT license; see LICENSE file.
+
+import os.path as osp
+import pytest
+import warnings
+
+import entrypoints_cache as entrypoints
+
+samples_dir = osp.join(osp.dirname(__file__), 'samples')
+
+sample_path = [
+    osp.join(samples_dir, 'packages1'),
+    osp.join(samples_dir, 'packages1', 'baz-0.3.egg'),
+    osp.join(samples_dir, 'packages2'),
+    osp.join(samples_dir, 'packages2', 'qux-0.4.egg'),
+]
+
+def test_get_group_all():
+    group = entrypoints.get_group_all('entrypoints.test1', sample_path)
+    print(group)
+    assert len(group) == 5
+    assert set(ep.name for ep in group) == {'abc', 'rew', 'opo', 'njn'}
+
+def test_get_group_named():
+    group = entrypoints.get_group_named('entrypoints.test1', sample_path)
+    print(group)
+    assert len(group) == 4
+    assert group['abc'].module_name == 'foo'
+    assert group['abc'].object_name == 'abc'
+
+def test_get_single():
+    ep = entrypoints.get_single('entrypoints.test1', 'abc', sample_path)
+    assert ep.module_name == 'foo'
+    assert ep.object_name == 'abc'
+
+    ep2 = entrypoints.get_single('entrypoints.test1', 'njn', sample_path)
+    assert ep.module_name == 'foo'
+    assert ep.object_name == 'abc'
+
+def test_dot_prefix():
+    ep = entrypoints.get_single('blogtool.parsers', '.rst', sample_path)
+    assert ep.object_name == 'SomeClass.some_classmethod'
+    assert ep.extras == ['reST']
+
+    group = entrypoints.get_group_named('blogtool.parsers', sample_path)
+    assert set(group.keys()) == {'.rst'}
+
+def test_case_sensitive():
+    group = entrypoints.get_group_named('test.case_sensitive', sample_path)
+    assert set(group.keys()) == {'Ptangle', 'ptangle'}
+
+def test_load():
+    import entrypoints_cache
+    ep = entrypoints.EntryPoint('get_ep', 'entrypoints_cache', 'get_single', None)
+    obj = ep.load()
+    assert obj is entrypoints_cache.get_single
+
+    # The object part is optional (e.g. pytest plugins use just a module ref)
+    ep = entrypoints.EntryPoint('ep_mod', 'entrypoints_cache', None)
+    obj = ep.load()
+    assert obj is entrypoints_cache
+
+def test_bad():
+    bad_path = [osp.join(samples_dir, 'packages3')]
+
+    with warnings.catch_warnings(record=True) as w:
+        group = entrypoints.get_group_named('entrypoints.test1', bad_path)
+
+    assert 'bad' not in group
+    assert len(w) == 1
+
+    with warnings.catch_warnings(record=True) as w2, \
+            pytest.raises(entrypoints.NoSuchEntryPoint):
+        ep = entrypoints.get_single('entrypoints.test1', 'bad')
+
+    assert len(w) == 1
+
+def test_missing():
+    with pytest.raises(entrypoints.NoSuchEntryPoint) as ec:
+        entrypoints.get_single('no.such.group', 'no_such_name', sample_path)
+
+    assert ec.value.group == 'no.such.group'
+    assert ec.value.name == 'no_such_name'
+
+def test_parse():
+    ep = entrypoints.EntryPoint.from_string(
+        'some.module:some.attr [extra1,extra2]', 'foo'
+    )
+    assert ep.module_name == 'some.module'
+    assert ep.object_name == 'some.attr'
+    assert ep.extras == ['extra1', 'extra2']
+
+def test_parse_bad():
+    with pytest.raises(entrypoints.BadEntryPoint):
+        entrypoints.EntryPoint.from_string("this won't work", 'foo')


### PR DESCRIPTION
This experimental patch builds on the existing caching work. It adds a
new module that should be API-compatible with the base module (as
demonstrated by the test file).

The cache stores the parsed text data from all of the ini input files
in a single JSON file with a name based on the hash of the path
entries and the mtimes. This should produce a unique filename for each
import path, regardless of the use of a virtualenv.

The data is stored in a format that means no other files need to be
examined or parsed in order to return EntryPoint objects.

Addresses #16

Signed-off-by: Doug Hellmann <doug@doughellmann.com>