### PR TITLE
use glob.escape() on the folder to allow paths with brackets []

### DIFF
--- a/entrypoints.py
+++ b/entrypoints.py
@@ -190,9 +190,11 @@ def iter_files_distros(path=None, repeated_distro='first'):
                     yield cp, distro
 
         # Regular file imports (not egg, not zip file)
+        # Fall back to unescaped for python versions < 3.4
+        folder_glob = glob.escape(folder) if hasattr(glob, 'escape') else folder
         for path in itertools.chain(
-            glob.iglob(osp.join(glob.escape(folder), '*.dist-info', 'entry_points.txt')),
-            glob.iglob(osp.join(glob.escape(folder), '*.egg-info', 'entry_points.txt'))
+            glob.iglob(osp.join(folder_glob, '*.dist-info', 'entry_points.txt')),
+            glob.iglob(osp.join(folder_glob, '*.egg-info', 'entry_points.txt'))
         ):
             distro_name_version = osp.splitext(osp.basename(osp.dirname(path)))[0]
             distro = Distribution.from_name_version(distro_name_version)

--- a/entrypoints.py
+++ b/entrypoints.py
@@ -191,8 +191,8 @@ def iter_files_distros(path=None, repeated_distro='first'):
 
         # Regular file imports (not egg, not zip file)
         for path in itertools.chain(
-            glob.iglob(osp.join(folder, '*.dist-info', 'entry_points.txt')),
-            glob.iglob(osp.join(folder, '*.egg-info', 'entry_points.txt'))
+            glob.iglob(osp.join(glob.escape(folder), '*.dist-info', 'entry_points.txt')),
+            glob.iglob(osp.join(glob.escape(folder), '*.egg-info', 'entry_points.txt'))
         ):
             distro_name_version = osp.splitext(osp.basename(osp.dirname(path)))[0]
             distro = Distribution.from_name_version(distro_name_version)


### PR DESCRIPTION
entrypoint fails to find the files if they are under a path with square brackets as glob tries to interpret them and fails.
Using `glob.escape(folder)` fixes that.
See https://github.com/ipython/ipython/issues/11512 for details