### PR TITLE
Fix compatibility with Sphinx 8

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -290,4 +290,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}


### PR DESCRIPTION
The issue detected:
```
ERROR: Invalid value `None` in intersphinx_mapping['https://docs.python.org/']. Expected a two-element tuple or list.

Configuration error:
Invalid `intersphinx_mapping` configuration (1 error).
```